### PR TITLE
Build docker files

### DIFF
--- a/.github/workflows/buildADocker.yml
+++ b/.github/workflows/buildADocker.yml
@@ -1,6 +1,9 @@
-name: Test
-    
-on: [push]
+name: upload-on-release 
+
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build:

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -1,0 +1,16 @@
+name: Build Notebook Container
+on: [push, pull_request]
+
+  build-image-without-pushing:
+    runs-on: ubuntu-latest
+    steps:  
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: test build
+      uses: machine-learning-apps/repo2docker-action@0.2
+      with:
+        NO_PUSH: 'true'
+        

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -1,6 +1,7 @@
 name: Build Notebook Container
 on: [push, pull_request]
 
+jobs:
   build-image-without-pushing:
     runs-on: ubuntu-latest
     steps:  

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -1,9 +1,13 @@
 name: Build Notebook Container
-on: [push, pull_request]
+
+on:
+  watch:
+    types: [started]
 
 jobs:
   build-image-without-pushing:
     runs-on: ubuntu-latest
+    if: github.actor == github.event.repository.owner.login
     steps:  
     - name: Checkout
       uses: actions/checkout@v2

--- a/postBuild
+++ b/postBuild
@@ -16,4 +16,4 @@ jupyter labextension install jupyter-leaflet
 
 # Trust notebooks in repo
 jupyter trust *.ipynb
-
+jupyter trust notebooks/*.ipynb


### PR DESCRIPTION
These appear to work OK, a couple of comments:
- I can't test the images locally as my hard disk is full (:eyeroll:)
- Triggering docker builds takes forever

There's a risk of race conditions and triggering too many time-consuming builds
So this pull request does two things:
1. Test docker builds without uploading to avoid conflicts. Currently, it triggers when **the owner of the repository clicks on the star icon for the repo**. It's a bit hacky, but that's the only way I've come across...
2. Build docker build and upload to docker hub. This is triggered when a tag starting by `v` (e.g. `v1.0`) is pushed. 


